### PR TITLE
Use metadata files instead of boxfiles

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-def linux config, ip, box, box_url, checksum
-  config.vm.define box.to_sym do |c|
+def linux config, ip, box, hostname, box_url, checksum
+  config.vm.define hostname.to_sym do |c|
     # Give the VM a public or private IP address. PS: By default, the vagrant
     # images are not secure to expose as they allow login with known keys and 
     # passwords.
@@ -24,7 +24,7 @@ def linux config, ip, box, box_url, checksum
 
     c.vm.box_url = box_url
     c.vm.box = box
-    c.vm.hostname = '%s.local' % box.to_sym
+    c.vm.hostname = '%s.local' % hostname.to_sym
     c.vm.boot_timeout = 900
 
     #config.vm.provision :puppet do |puppet|
@@ -35,31 +35,32 @@ def linux config, ip, box, box_url, checksum
   end
 end
 
+# hostname, ip, box, box_url, checksum
 Vagrant.configure('2') do |config|
-  linux config, '10.0.0.2',  'centos5-amd64', 'https://images.varnish-software.com/vagrant/centos-5-amd64-virtualbox.box',     '1981255ec30f9f6499e0be90dc25d435'
-  linux config, '10.0.0.3',  'centos5-i386',  'https://images.varnish-software.com/vagrant/centos-5-i386-virtualbox.box',      'c17f4c1c0e87c056d20887cde4d9640a'
-  linux config, '10.0.0.4',  'centos6-amd64', 'https://images.varnish-software.com/vagrant/centos-6-amd64-virtualbox.box',     'bf5516467b0505781b72f9ea823b1d61'
-  linux config, '10.0.0.5',  'centos6-i386',  'https://images.varnish-software.com/vagrant/centos-6-i386-virtualbox.box',      '3799f126d0326f4ae00604d9ccb181a3'
-  linux config, '10.0.0.6',  'centos7-amd64', 'https://images.varnish-software.com/vagrant/centos-7-amd64-virtualbox.box',     '53d9207739af6849b91cdc75f7b7f85c'
-  linux config, '10.0.0.10', 'precise-amd64', 'https://images.varnish-software.com/vagrant/ubuntu-12.04-amd64-virtualbox.box', 'b211b4dcb8bc60a45ea3317a706bb6b8'
-  linux config, '10.0.0.11', 'precise-i386',  'https://images.varnish-software.com/vagrant/ubuntu-12.04-i386-virtualbox.box',  'ee0fa957b5ef4a03eb0220a73dd0cb49'
-  linux config, '10.0.0.12', 'trusty-amd64',  'https://images.varnish-software.com/vagrant/ubuntu-14.04-amd64-virtualbox.box', 'c5ce0e694d3de05300ebbe0dc65c624e'
-  linux config, '10.0.0.13', 'trusty-i386',   'https://images.varnish-software.com/vagrant/ubuntu-14.04-i386-virtualbox.box',  'ba58bcbfbf6121b8bdc29d0c82870a39'
-  linux config, '10.0.0.20', 'squeeze-amd64', 'https://images.varnish-software.com/vagrant/debian-6-amd64-virtualbox.box',     'dc90ff3a7c0944cd713fc9d6c7f42631'
-  linux config, '10.0.0.21', 'squeeze-i386',  'https://images.varnish-software.com/vagrant/debian-6-i386-virtualbox.box',      '2d6e1ab1e0d5db4196275f3f2eecc882'
-  linux config, '10.0.0.22', 'wheezy-amd64',  'https://images.varnish-software.com/vagrant/debian-7-amd64-virtualbox.box',     '5f2963d6d54f5da5dda06f25ddd35b5c'
-  linux config, '10.0.0.23', 'wheezy-i386',   'https://images.varnish-software.com/vagrant/debian-7-i386-virtualbox.box',      '0a9337426c2e97d9f53883cbbafadb49'
-  linux config, '10.0.0.24', 'jessie-amd64',  'https://images.varnish-software.com/vagrant/debian-8-amd64-virtualbox.box',     '3305915a7f7688656a8a144f863ca37c'
+  linux config, '10.0.0.2',  'varnish/centos-5-amd64',     'centos-5-amd64',     'https://images.varnish-software.com/vagrant/centos-5-amd64-virtualbox.box',   '1981255ec30f9f6499e0be90dc25d435'
+  linux config, '10.0.0.3',  'varnish/centos-5-i386',      'centos-5-i386',      'https://images.varnish-software.com/vagrant/centos-5-i386-virtualbox.box',    'c17f4c1c0e87c056d20887cde4d9640a'
+  linux config, '10.0.0.4',  'varnish/centos-6-amd64',     'centos-6-amd64',     'https://images.varnish-software.com/vagrant/centos-6-amd64.json',             'md5sum is in json file'
+  linux config, '10.0.0.5',  'varnish/centos-6-i386',      'centos-6-i386',      'https://images.varnish-software.com/vagrant/centos-6-i386-virtualbox.box',    '3799f126d0326f4ae00604d9ccb181a3'
+  linux config, '10.0.0.6',  'varnish/centos-7-amd64',     'centos-7-amd64',     'https://images.varnish-software.com/vagrant/centos-7-amd64.json',             'md5sum is in json file'
+  linux config, '10.0.0.10', 'varnish/ubuntu-12.04-amd64', 'ubuntu-12.04-amd64', 'https://images.varnish-software.com/vagrant/ubuntu-12.04-amd64.json',         'md5sum is in json file'
+  linux config, '10.0.0.11', 'varnish/ubuntu-12.04-i386',  'ubuntu-12.04-i386',  'https://images.varnish-software.com/vagrant/ubuntu-12.04-i386-virtualbox.box','ee0fa957b5ef4a03eb0220a73dd0cb49'
+  linux config, '10.0.0.12', 'varnish/ubuntu-14.04-amd64', 'ubuntu-14.04-amd64', 'https://images.varnish-software.com/vagrant/ubuntu-14.04-amd64.json',         'md5sum is in json file'
+  linux config, '10.0.0.13', 'varnish/ubuntu-14.04-i386',  'ubuntu-14.04-i386',  'https://images.varnish-software.com/vagrant/ubuntu-14.04-i386-virtualbox.box','ba58bcbfbf6121b8bdc29d0c82870a39'
+  linux config, '10.0.0.20', 'varnish/debian-6-amd64',     'debian-6-amd64',     'https://images.varnish-software.com/vagrant/debian-6-amd64-virtualbox.box',   'dc90ff3a7c0944cd713fc9d6c7f42631'
+  linux config, '10.0.0.21', 'varnish/debian-6-i386',      'debian-6-i386',      'https://images.varnish-software.com/vagrant/debian-6-i386-virtualbox.box',    '2d6e1ab1e0d5db4196275f3f2eecc882'
+  linux config, '10.0.0.22', 'varnish/debian-7-amd64',     'debian-7-amd64',     'https://images.varnish-software.com/vagrant/debian-7-amd64.json',             'md5sum is in json file'
+  linux config, '10.0.0.23', 'varnish/debian-7-i386',      'debian-7-i386',      'https://images.varnish-software.com/vagrant/debian-7-i386-virtualbox.box',    '0a9337426c2e97d9f53883cbbafadb49'
+  linux config, '10.0.0.24', 'varnish/debian-8-amd64',     'debian-8-amd64',     'https://images.varnish-software.com/vagrant/debian-8-amd64.json',             'md5sum is in json file'
 end
 
 
-def freebsd config, ip, box, box_url, checksum
-  config.vm.define box.to_sym do |c|
+def freebsd config, ip, box, hostname, box_url, checksum
+  config.vm.define hostname.to_sym do |c|
     c.vm.network :private_network, ip: ip
     c.vm.synced_folder ".", "/vagrant", :nfs => true, id: "vagrant-root"
     c.vm.box_url = box_url
     c.vm.box = box
-    c.vm.hostname = '%s.local' % box.to_sym
+    c.vm.hostname = '%s.local' % hostname.to_sym
     c.vm.boot_timeout = 900
 
     #config.vm.provision :puppet do |puppet|
@@ -71,7 +72,7 @@ def freebsd config, ip, box, box_url, checksum
 end
 
 Vagrant.configure('2') do |config|
-  freebsd config, '10.0.0.30', 'freebsd10-amd64', 'https://images.varnish-software.com/vagrant/freebsd-10-amd64-virtualbox.box', 'abc01a675cfcff0a2c8eddefb17da013'
-  freebsd config, '10.0.0.31', 'freebsd10-i386', 'https://images.varnish-software.com/vagrant/freebsd-10-i386-virtualbox.box', '92d549cc2ed2b34b6038f27fb1e165c0'
+  freebsd config, '10.0.0.30', 'varnish/freebsd-10-amd64', 'freebsd-10-amd64', 'https://images.varnish-software.com/vagrant/freebsd-10-amd64-virtualbox.box', 'abc01a675cfcff0a2c8eddefb17da013'
+  freebsd config, '10.0.0.31', 'varnish/freebsd-10-i386',  'freebsd-10-i386',  'https://images.varnish-software.com/vagrant/freebsd-10-i386-virtualbox.box',  '92d549cc2ed2b34b6038f27fb1e165c0'
 end
 


### PR DESCRIPTION
To better make use of Vagrants built-in support for checksums
and versions, we now use the .json metadata files in Vagrant instead
of adding boxfiles directly.

This change also adds a hostname that is separate from the boxname
to make it quicker to refer to vagrantboxes on the cli.

The Debian-based, and FreeBSD guests were also renamed so that 
all have the same distro-version-arch name-scheme, instead of some
having codenames.
