### PR TITLE
Specify a shell for the FreeBSD boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,7 @@ end
 
 
 def freebsd config, ip, box, hostname, box_url, checksum
+  config.ssh.shell = "/bin/sh"
   config.vm.define hostname.to_sym do |c|
     c.vm.network :private_network, ip: ip
     c.vm.synced_folder ".", "/vagrant", :nfs => true, id: "vagrant-root"


### PR DESCRIPTION
For some reason Vagrant fails to launch the VM with a login shell:

> The configured shell (config.ssh.shell) is invalid and unable
> to properly execute commands. The most common cause for this is
> using a shell that is unavailable on the system. Please verify
> you're using the full path to the shell and that the shell is
> executable by the SSH user.
